### PR TITLE
feat: add vector function support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import { connect, Connection, Tx, Config, FullResult } from '@tidbcloud/serverless';
-
 import {
   CompiledQuery,
   DatabaseConnection,
@@ -8,11 +6,22 @@ import {
   Driver,
   Kysely,
   MysqlAdapter,
-  MysqlQueryCompiler,
   MysqlIntrospector,
+  MysqlQueryCompiler,
   QueryCompiler,
   QueryResult,
 } from 'kysely';
+import { Config, Connection, FullResult, Tx, connect } from '@tidbcloud/serverless';
+import {
+  cosineDistance,
+  cosineSimilarity,
+  innerProduct,
+  l1Distance,
+  l2Distance,
+  negativeInnerProduct,
+  vectorFromSql,
+  vectorToSql,
+} from './vector';
 
 /**
  * Config for the TiDB Serverless dialect.
@@ -171,3 +180,14 @@ class TiDBServerlessTransaction {
     await this.#tx.rollback();
   }
 }
+
+export {
+  cosineDistance,
+  cosineSimilarity,
+  innerProduct,
+  l1Distance,
+  l2Distance,
+  negativeInnerProduct,
+  vectorFromSql,
+  vectorToSql,
+};

--- a/src/vector.ts
+++ b/src/vector.ts
@@ -1,0 +1,38 @@
+import { RawBuilder, sql } from 'kysely';
+
+type VectorLike = Float32Array | number[];
+
+export function l1Distance(column: string, value: VectorLike): RawBuilder<number> {
+  return sql`VEC_L1_DISTANCE(${sql.ref(column)}, ${vectorToSql(value)})`;
+}
+
+export function l2Distance(column: string, value: VectorLike): RawBuilder<number> {
+  return sql`VEC_L2_DISTANCE(${sql.ref(column)}, ${vectorToSql(value)})`;
+}
+
+export function negativeInnerProduct(column: string, value: VectorLike): RawBuilder<number> {
+  return sql`VEC_NEGATIVE_INNER_PRODUCT(${sql.ref(column)}, ${vectorToSql(value)})`;
+}
+
+export function innerProduct(column: string, value: VectorLike): RawBuilder<number> {
+  return sql`1 - VEC_NEGATIVE_INNER_PRODUCT(${sql.ref(column)}, ${vectorToSql(value)})`;
+}
+
+export function cosineDistance(column: string, value: VectorLike): RawBuilder<number> {
+  return sql`VEC_COSINE_DISTANCE(${sql.ref(column)}, ${vectorToSql(value)})`;
+}
+
+export function cosineSimilarity(column: any, value: VectorLike): RawBuilder<number> {
+  return sql`1 - VEC_COSINE_DISTANCE(${sql.ref(column)}, ${vectorToSql(value)})`;
+}
+
+export function vectorFromSql(value: string) {
+  return value
+    .substring(1, value.length - 1)
+    .split(',')
+    .map((v) => parseFloat(v));
+}
+
+export function vectorToSql(vector: VectorLike) {
+  return `[${vector.join(',')}]`;
+}

--- a/src/vector.ts
+++ b/src/vector.ts
@@ -2,39 +2,51 @@ import { ExpressionBuilder, ReferenceExpression } from 'kysely';
 
 type VectorLike = Float32Array | number[];
 
-export function l1Distance<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(eb: ExpressionBuilder<DB, TB>, column: RE, value: VectorLike) {
-  return eb.fn<number>('VEC_L1_DISTANCE', [
-    column,
-    eb => eb.val(vectorToSql(value))],
-  );
+export function l1Distance<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(
+  eb: ExpressionBuilder<DB, TB>,
+  column: RE,
+  value: VectorLike
+) {
+  return eb.fn<number>('VEC_L1_DISTANCE', [column, (eb) => eb.val(vectorToSql(value))]);
 }
 
-export function l2Distance<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(eb: ExpressionBuilder<DB, TB>, column: RE, value: VectorLike) {
-  return eb.fn<number>('VEC_L2_DISTANCE', [
-    column,
-    eb => eb.val(vectorToSql(value))],
-  );
+export function l2Distance<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(
+  eb: ExpressionBuilder<DB, TB>,
+  column: RE,
+  value: VectorLike
+) {
+  return eb.fn<number>('VEC_L2_DISTANCE', [column, (eb) => eb.val(vectorToSql(value))]);
 }
 
-export function negativeInnerProduct<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(eb: ExpressionBuilder<DB, TB>, column: RE, value: VectorLike) {
-  return eb.fn<number>('VEC_NEGATIVE_INNER_PRODUCT', [
-    column,
-    eb => eb.val(vectorToSql(value))],
-  );
+export function negativeInnerProduct<
+  DB,
+  TB extends keyof DB,
+  RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>
+>(eb: ExpressionBuilder<DB, TB>, column: RE, value: VectorLike) {
+  return eb.fn<number>('VEC_NEGATIVE_INNER_PRODUCT', [column, (eb) => eb.val(vectorToSql(value))]);
 }
 
-export function innerProduct<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(eb: ExpressionBuilder<DB, TB>, column: RE, value: VectorLike) {
+export function innerProduct<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(
+  eb: ExpressionBuilder<DB, TB>,
+  column: RE,
+  value: VectorLike
+) {
   return eb.neg(negativeInnerProduct(eb, column, value));
 }
 
-export function cosineDistance<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(eb: ExpressionBuilder<DB, TB>, column: RE, value: VectorLike) {
-  return  eb.fn<number>('VEC_COSINE_DISTANCE', [
-    column,
-    eb => eb.val(vectorToSql(value))],
-  );
+export function cosineDistance<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(
+  eb: ExpressionBuilder<DB, TB>,
+  column: RE,
+  value: VectorLike
+) {
+  return eb.fn<number>('VEC_COSINE_DISTANCE', [column, (eb) => eb.val(vectorToSql(value))]);
 }
 
-export function cosineSimilarity<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(eb: ExpressionBuilder<DB, TB>, column: RE, value: VectorLike) {
+export function cosineSimilarity<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(
+  eb: ExpressionBuilder<DB, TB>,
+  column: RE,
+  value: VectorLike
+) {
   return eb(eb.lit<number>(1), '-', cosineDistance(eb, column, value));
 }
 

--- a/src/vector.ts
+++ b/src/vector.ts
@@ -1,29 +1,41 @@
-import { RawBuilder, sql } from 'kysely';
+import { ExpressionBuilder, ReferenceExpression } from 'kysely';
 
 type VectorLike = Float32Array | number[];
 
-export function l1Distance(column: string, value: VectorLike): RawBuilder<number> {
-  return sql`VEC_L1_DISTANCE(${sql.ref(column)}, ${vectorToSql(value)})`;
+export function l1Distance<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(eb: ExpressionBuilder<DB, TB>, column: RE, value: VectorLike) {
+  return eb.fn<number>('VEC_L1_DISTANCE', [
+    column,
+    eb => eb.val(vectorToSql(value))],
+  );
 }
 
-export function l2Distance(column: string, value: VectorLike): RawBuilder<number> {
-  return sql`VEC_L2_DISTANCE(${sql.ref(column)}, ${vectorToSql(value)})`;
+export function l2Distance<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(eb: ExpressionBuilder<DB, TB>, column: RE, value: VectorLike) {
+  return eb.fn<number>('VEC_L2_DISTANCE', [
+    column,
+    eb => eb.val(vectorToSql(value))],
+  );
 }
 
-export function negativeInnerProduct(column: string, value: VectorLike): RawBuilder<number> {
-  return sql`VEC_NEGATIVE_INNER_PRODUCT(${sql.ref(column)}, ${vectorToSql(value)})`;
+export function negativeInnerProduct<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(eb: ExpressionBuilder<DB, TB>, column: RE, value: VectorLike) {
+  return eb.fn<number>('VEC_NEGATIVE_INNER_PRODUCT', [
+    column,
+    eb => eb.val(vectorToSql(value))],
+  );
 }
 
-export function innerProduct(column: string, value: VectorLike): RawBuilder<number> {
-  return sql`1 - VEC_NEGATIVE_INNER_PRODUCT(${sql.ref(column)}, ${vectorToSql(value)})`;
+export function innerProduct<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(eb: ExpressionBuilder<DB, TB>, column: RE, value: VectorLike) {
+  return eb.neg(negativeInnerProduct(eb, column, value));
 }
 
-export function cosineDistance(column: string, value: VectorLike): RawBuilder<number> {
-  return sql`VEC_COSINE_DISTANCE(${sql.ref(column)}, ${vectorToSql(value)})`;
+export function cosineDistance<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(eb: ExpressionBuilder<DB, TB>, column: RE, value: VectorLike) {
+  return  eb.fn<number>('VEC_COSINE_DISTANCE', [
+    column,
+    eb => eb.val(vectorToSql(value))],
+  );
 }
 
-export function cosineSimilarity(column: any, value: VectorLike): RawBuilder<number> {
-  return sql`1 - VEC_COSINE_DISTANCE(${sql.ref(column)}, ${vectorToSql(value)})`;
+export function cosineSimilarity<DB, TB extends keyof DB, RE extends ReferenceExpression<DB, TB> = ReferenceExpression<DB, TB>>(eb: ExpressionBuilder<DB, TB>, column: RE, value: VectorLike) {
+  return eb(eb.lit<number>(1), '-', cosineDistance(eb, column, value));
 }
 
 export function vectorFromSql(value: string) {


### PR DESCRIPTION
Inspired by the pgvector-node package: https://github.com/pgvector/pgvector-node/blob/master/src/kysely/index.js

Simplifies the use of TiDB Serverless Vector Function for kysely developers while providing better code hints.

For example:

```diff
db.selectFrom('document_index_chunk')
      .innerJoin('document', 'document_id', 'document.id')
      .select([
        'document_index_chunk.id as document_index_chunk_id',
        'document_id',
        'document_index_chunk.text_content',
        'document_index_chunk.metadata',
        'source_uri',
        'document.name as source_name',
-        eb => eb(eb => eb.lit<number>(1), '-', eb.fn<number>('vec_cosine_distance', [
-          'embedding',
-          eb => eb.val(vectorToVal(vector))],
-        )).as('score'),
+        (eb) => cosineSimilarity(eb, 'embedding', vector).as('score')
      ])
      .where('staled', '=', 0)
      .where('index_name', '=', eb => eb.val(index))
      .orderBy('score desc')
      .limit(top_k);
```
